### PR TITLE
fix for not supported username parameter in GDPR strict mode

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -186,7 +186,7 @@ export default class JiraApi {
     getUsers(username: string): Promise<Array<Jira.User>> {
         return this.api.isMock
             ? JiraMocksApi.getUsers(username)
-            : this.api.get(`/rest/api/2/user/search?username=${encodeURIComponent(username)}`);
+            : this.api.get(`/rest/api/2/user/search?query=${encodeURIComponent(username)}`);
     }
 
     getGroupsForPicker(query: { query: string }) {


### PR DESCRIPTION
according to this [link](https://developer.atlassian.com/cloud/jira/platform/api-changes-for-user-privacy-announcement/) username field as query parameter is no longer supported.